### PR TITLE
Minor Fix

### DIFF
--- a/sources/gmsi/service/communication/telegraph_engine/telegraph_engine.c
+++ b/sources/gmsi/service/communication/telegraph_engine/telegraph_engine.c
@@ -484,7 +484,7 @@ private bool try_to_send_telegraph( telegraph_t *ptTelegraph,
                 break;
             }
             
-            target.ptOUTData = NULL;
+            //never do this! :target.ptOUTData = NULL;
             
             //! request timeout service
             if (target.wTimeout > 0) {

--- a/sources/gmsi/service/memory/stream2block/stream2block.h
+++ b/sources/gmsi/service/memory/stream2block/stream2block.h
@@ -106,7 +106,7 @@
                                                                                 \
         struct {                                                                \
             bool (*Write)(uint8_t);                                             \
-            void (*Flush)(void);                                                \
+            bool (*Flush)(void);                                                \
         } Stream;                                                               \
                                                                                 \
         struct {                                                                \
@@ -125,9 +125,9 @@
         return STREAM_BUFFER.Stream.WriteByte(                                  \
                                         &s_t##__NAME##StreamBuffer, chData);    \
     }                                                                           \
-    private void __NAME##_stream_flush(void)                                    \
+    private bool __NAME##_stream_flush(void)                                    \
     {                                                                           \
-        while(!STREAM_BUFFER.Stream.Flush(&s_t##__NAME##StreamBuffer));         \
+        return STREAM_BUFFER.Stream.Flush(&s_t##__NAME##StreamBuffer);         \
     }                                                                           \
     __OUTPUT_STREAM_BUFFER_COMMON(__NAME) = {                                   \
             .Init =         &__NAME##_stream_buffer_init,                       \

--- a/sources/gmsi/service/time/multiple_delay/multiple_delay.c
+++ b/sources/gmsi/service/time/multiple_delay/multiple_delay.c
@@ -185,7 +185,6 @@ private void add_to_delay_list(  multiple_delay_item_t *ptItem,
                                 multiple_delay_item_t **ppList) 
 {
     class_internal(ptItem, ptTarget, multiple_delay_item_t);
-    
     __MD_ATOM_ACCESS (
         do {
             class_internal((*ppList), ptListItem, multiple_delay_item_t);
@@ -195,7 +194,8 @@ private void add_to_delay_list(  multiple_delay_item_t *ptItem,
                 break;
             }
             
-            if (ptListItem->wTargetTime >= target.wTargetTime) {
+            if (target.wTargetTime <= ptListItem->wTargetTime) {
+                
                 LIST_INSERT_AFTER((*ppList), ptItem);
                 break;
             }
@@ -354,6 +354,7 @@ private void insert_timer_tick_event_handler(multiple_delay_t *ptObj)
             if (NULL == this.ptDelayList) {
                 this.wCounter = 0;
                 this.wOldCounter = 0;
+                this.wSavedCounter = 0;
                 break;
             }
         } else {
@@ -363,6 +364,10 @@ private void insert_timer_tick_event_handler(multiple_delay_t *ptObj)
                                 ptTarget, 
                                 multiple_delay_item_t);
                                 
+                if (NULL == ptTarget) {
+                    break;
+                }
+                
                 if (target.wTargetTime <= this.wCounter) {
                     //! timeout detected
                     LIST_STACK_POP(this.ptHighPriorityDelayList, ptTarget);
@@ -468,7 +473,7 @@ private fsm_implementation(multiple_delay_task)
                 }
                 
                 if (ptItem->wTargetTime <= target.wSavedCounter) {
-                    
+ 
                     __MD_ATOM_ACCESS (
                         //! timeout detected
                         LIST_STACK_POP(target.ptDelayList, ptItem);


### PR DESCRIPTION
- Fix the issues in multiple delay service
    > In some rare case, a delay request might timeout immediately. It has been fixed.
    > hardfault issue has been fixed
- For pure listener, the ptOUTData should not be cleared to NULL.
- Minor fix in stream2block service template. Flush method now has return value.