### PR TITLE
Make Utilities standalone

### DIFF
--- a/example/build/mdk/Blinky.uvoptx
+++ b/example/build/mdk/Blinky.uvoptx
@@ -211,6 +211,7 @@
       <pMultCmdsp></pMultCmdsp>
       <DebugDescription>
         <Enable>1</Enable>
+        <EnableFlashSeq>0</EnableFlashSeq>
         <EnableLog>0</EnableLog>
         <Protocol>2</Protocol>
         <DbgClock>10000000</DbgClock>
@@ -440,7 +441,7 @@
 
   <Group>
     <GroupName>gmsi</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -988,7 +989,7 @@
       <GroupNumber>3</GroupNumber>
       <FileNumber>49</FileNumber>
       <FileType>1</FileType>
-      <tvExp>0</tvExp>
+      <tvExp>1</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
       <PathWithFileName>..\..\..\sources\gmsi\service\memory\block\block.c</PathWithFileName>

--- a/example/build/mdk/Blinky.uvprojx
+++ b/example/build/mdk/Blinky.uvprojx
@@ -184,6 +184,7 @@
             <hadXRAM>0</hadXRAM>
             <uocXRam>0</uocXRam>
             <RvdsVP>2</RvdsVP>
+            <RvdsMve>0</RvdsMve>
             <hadIRAM2>0</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>
@@ -868,6 +869,7 @@
             <hadXRAM>0</hadXRAM>
             <uocXRam>0</uocXRam>
             <RvdsVP>2</RvdsVP>
+            <RvdsMve>0</RvdsMve>
             <hadIRAM2>1</hadIRAM2>
             <hadIROM2>0</hadIROM2>
             <StupSel>8</StupSel>

--- a/sources/environment_cfg.h
+++ b/sources/environment_cfg.h
@@ -23,7 +23,7 @@
 
 #define __CPU_ARM__                      //!< arm family
 
-#define __CORTEX_M7__                    //!< cortex-m0
+//#define __CORTEX_M7__                    //!< cortex-m0
 //#define __CORTEX_M0P__                   //!< cortex-m0+
 //#define __CORTEX_M1__                    //!< cortex-m1
 //#define __CORTEX_M3__                    //!< cortex-m3

--- a/sources/gmsi/utilities/arm/arm_compiler.h
+++ b/sources/gmsi/utilities/arm/arm_compiler.h
@@ -294,7 +294,13 @@ __attribute__((always_inline)) static inline void __set_PRIMASK(unsigned int pri
 #elif   defined(__CORTEX_M33__)
 #include "cortex_m33_compiler.h"
 #else
-#error No supported compiler.h file!
+
+//! \brief The mcu memory endian mode
+# define __BIG_ENDIAN__                 false
+
+/*ARM Cortex M4 implementation for interrupt priority shift*/
+# define ARM_INTERRUPT_LEVEL_BITS       4
+
 #endif
 
 /*!  \note using the ANSI-C99 standard type,if the file stdint.h dose not exit

--- a/sources/gmsi/utilities/compiler.h
+++ b/sources/gmsi/utilities/compiler.h
@@ -76,12 +76,14 @@
 #include ".\preprocessor\mrepeat.h"
      
 //! \brief CPU io
-#if     defined(__CPU_ARM__)                    //!< ARM series
-    #include ".\arm\arm_compiler.h"
-#elif   defined(__CPU_AVR__)                    //!< Atmel AVR series
-    #include ".\avr\avr_compiler.h"
+
+#if     defined(__CPU_AVR__)                    //!< Atmel AVR series
+#   include ".\avr\avr_compiler.h"
+#elif   defined(__CPU_ARM__)                //!< ARM series
+#   include ".\arm\arm_compiler.h"
 #else
-#error No specified MCU type!
+//#warning No specified MCU type! use arm as default
+#   include ".\arm\arm_compiler.h"
 #endif
    
 #ifndef ATOM_INT_SIZE


### PR DESCRIPTION
The utilities can be used as a standalone component.
Simply using
#include "utilities\compiler.h"
for all Cortex-M Compilers.