### PR TITLE
Refine the signal in utilities

### DIFF
--- a/example/build/mdk/Blinky.uvoptx
+++ b/example/build/mdk/Blinky.uvoptx
@@ -148,40 +148,7 @@
           <Name>(105=-1,-1,-1,-1,0)(106=-1,-1,-1,-1,0)(107=-1,-1,-1,-1,0)</Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
-      <Breakpoint>
-        <Bp>
-          <Number>0</Number>
-          <Type>0</Type>
-          <LineNumber>543</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>5098</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>1</BreakIfRCount>
-          <Filename>..\..\system.c</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression>\\Blinky\../../system.c\543</Expression>
-        </Bp>
-        <Bp>
-          <Number>1</Number>
-          <Type>0</Type>
-          <LineNumber>548</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>0</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
-          <Filename>..\..\system.c</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression></Expression>
-        </Bp>
-      </Breakpoint>
+      <Breakpoint/>
       <MemoryWindow1>
         <Mm>
           <WinNumber>1</WinNumber>
@@ -497,7 +464,7 @@
 
   <Group>
     <GroupName>gmsi</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>0</RteFlg>
@@ -505,7 +472,7 @@
       <GroupNumber>3</GroupNumber>
       <FileNumber>4</FileNumber>
       <FileType>1</FileType>
-      <tvExp>0</tvExp>
+      <tvExp>1</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
       <PathWithFileName>..\..\..\sources\gmsi\utilities\ooc.c</PathWithFileName>
@@ -1045,7 +1012,7 @@
       <GroupNumber>3</GroupNumber>
       <FileNumber>49</FileNumber>
       <FileType>1</FileType>
-      <tvExp>1</tvExp>
+      <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
       <PathWithFileName>..\..\..\sources\gmsi\service\memory\block\block.c</PathWithFileName>

--- a/sources/gmsi/utilities/arm/arm_compiler.h
+++ b/sources/gmsi/utilities/arm/arm_compiler.h
@@ -20,9 +20,7 @@
 #define __USE_ARM_COMPILER_H__
 
 /*============================ INCLUDES ======================================*/
-#if __IS_COMPILER_IAR__
-#   include<intrinsics.h>
-#endif
+#include <cmsis_compiler.h>
 
 /*============================ MACROS ========================================*/
 
@@ -81,14 +79,12 @@
             REG_RSVD_0x100
 #endif
 
-//! ALU integer width in byte
-# define ATOM_INT_SIZE                   4
 
 //! \brief The mcu memory align mode
-# define MCU_MEM_ALIGN_SIZE             ATOM_INT_SIZE
+# define MCU_MEM_ALIGN_SIZE             sizeof(int)
 
 #ifndef __volatile__
-#define __volatile__
+#define __volatile__                    volatile
 #endif
 
 //! \brief 1 cycle nop operation
@@ -114,30 +110,8 @@
 #   define __SECTION(__SEC)     _Pragma(__STR(location=__SEC))
 #   define __WEAK_ALIAS(__ORIGIN, __ALIAS) \
                                 _Pragma(__STR(weak __ORIGIN=__ALIAS))
-
 #   define PACKED               __packed
 #   define UNALIGNED            __packed
-#   define TRANSPARENT_UNION    __attribute__((transparent_union))
-
-#elif __IS_COMPILER_GCC__
-#   define ROM_FLASH            __attribute__(( section( ".rom.flash"))) const
-#   define ROM_EEPROM           __attribute__(( section( ".rom.eeprom"))) const
-#   define NO_INIT              __attribute__(( section( ".bss.noinit")))
-#   define ROOT                 __attribute__((used))    
-#   define INLINE               inline
-#   define NO_INLINE            __attribute__((noinline))
-#   define ALWAYS_INLINE        __attribute__((always_inline))
-#   define WEAK                 __attribute__((weak))
-#   define RAMFUNC              __attribute__((section (".textrw")))
-#   define __asm__              __asm
-#   define __ALIGN(__N)         __attribute__((aligned (__N)))
-#   define __AT_ADDR(__ADDR)    __attribute__((at(__ADDR))) 
-#   define __SECTION(__SEC)     __attribute__((section (__SEC)))
-#   define __WEAK_ALIAS(__ORIGIN, __ALIAS) \
-                                __attribute__((weakref(__STR(__ALIAS))))
-
-#   define PACKED               __attribute__((packed))
-#   define UNALIGNED            __attribute__((packed))
 #   define TRANSPARENT_UNION    __attribute__((transparent_union))
 
 #elif __IS_COMPILER_ARM_COMPILER_5__
@@ -182,6 +156,27 @@
 #   define UNALIGNED            __unaligned
 #   define TRANSPARENT_UNION    __attribute__((transparent_union))
 
+#else  /*__IS_COMPILER_GCC__: Using GCC as default for those GCC compliant compilers*/
+#   define ROM_FLASH            __attribute__(( section( ".rom.flash"))) const
+#   define ROM_EEPROM           __attribute__(( section( ".rom.eeprom"))) const
+#   define NO_INIT              __attribute__(( section( ".bss.noinit")))
+#   define ROOT                 __attribute__((used))    
+#   define INLINE               inline
+#   define NO_INLINE            __attribute__((noinline))
+#   define ALWAYS_INLINE        __attribute__((always_inline))
+#   define WEAK                 __attribute__((weak))
+#   define RAMFUNC              __attribute__((section (".textrw")))
+#   define __asm__              __asm
+#   define __ALIGN(__N)         __attribute__((aligned (__N)))
+#   define __AT_ADDR(__ADDR)    __attribute__((at(__ADDR))) 
+#   define __SECTION(__SEC)     __attribute__((section (__SEC)))
+#   define __WEAK_ALIAS(__ORIGIN, __ALIAS) \
+                                __attribute__((weakref(__STR(__ALIAS))))
+
+#   define PACKED               __attribute__((packed))
+#   define UNALIGNED            __attribute__((packed))
+#   define TRANSPARENT_UNION    __attribute__((transparent_union))
+
 #endif
 
 #define WEAK_ALIAS(__ORIGIN, __ALIAS)   \
@@ -197,68 +192,64 @@
   /*!< Macro to enable all interrupts. */
 #if __IS_COMPILER_IAR__
 #   define ENABLE_GLOBAL_INTERRUPT()            __enable_interrupt()
-#elif __IS_COMPILER_ARM_COMPILER_5__ 
-#   define ENABLE_GLOBAL_INTERRUPT()            __enable_irq()
-#elif __IS_COMPILER_ARM_COMPILER_6__
-#   define ENABLE_GLOBAL_INTERRUPT()            __asm__ __volatile__ (" CPSIE i")
 #else
-#   define ENABLE_GLOBAL_INTERRUPT()            __asm__ __volatile__ (" CPSIE i")
+#   define ENABLE_GLOBAL_INTERRUPT()            __enable_irq()
 #endif
 
   /*!< Macro to disable all interrupts. */
 #if __IS_COMPILER_IAR__
-#   define DISABLE_GLOBAL_INTERRUPT()           __disable_interrupt()
+#   define DISABLE_GLOBAL_INTERRUPT()           ____disable_irq()
+
+static ALWAYS_INLINE uint32_t ____disable_irq(void) 
+{
+    uint32_t wPRIMASK = __get_interrupt_state();
+    __disable_irq();
+    return wPRIMASK & 0x1;
+}
+
 #elif __IS_COMPILER_ARM_COMPILER_5__
 #   define DISABLE_GLOBAL_INTERRUPT()           __disable_irq()
 #elif __IS_COMPILER_ARM_COMPILER_6__
+#   define DISABLE_GLOBAL_INTERRUPT()           __disable_irq()
+#elif __IS_COMPILER_GCC_
+#   define DISABLE_GLOBAL_INTERRUPT()           __disable_irq()
+#else /* for other compilers, using gcc assembly syntax to implement */
+
 #   define DISABLE_GLOBAL_INTERRUPT()           ____disable_irq()
 
-static __inline__ unsigned int __attribute__((__always_inline__, __nodebug__))
-____disable_irq(void) {
-  unsigned int cpsr;
-
-  __asm__ __volatile__("mrs %[cpsr], primask\n"
-                       "cpsid i\n"
-                       : [cpsr] "=r"(cpsr));
-  return cpsr & 0x1;
-}
-
-/**
-  \brief   Set Priority Mask
-  \details Assigns the given value to the Priority Mask Register.
-  \param [in]    priMask  Priority Mask
- */
-__attribute__((always_inline)) static inline void ____set_PRIMASK(unsigned int priMask)
+static ALWAYS_INLINE uint32_t ____disable_irq(void) 
 {
-    __asm__ volatile ("MSR primask, %0" : : "r" (priMask) : "memory");
-}
+    uint32_t cpsr;
 
-#else
-#   define DISABLE_GLOBAL_INTERRUPT()           __asm__ __volatile__ (" CPSID i");
+    __asm__ __volatile__("mrs %[cpsr], primask\n"
+                        "cpsid i\n"
+                        : [cpsr] "=r"(cpsr));
+    return cpsr & 0x1;
+}
 #endif
 
 #if __IS_COMPILER_IAR__
 #   define GET_GLOBAL_INTERRUPT_STATE()         __get_interrupt_state()
 #   define SET_GLOBAL_INTERRUPT_STATE(__STATE)  __set_interrupt_state(__STATE)
 typedef __istate_t   istate_t;
-#elif __IS_COMPILER_ARM_COMPILER_5__ 
-#   define GET_GLOBAL_INTERRUPT_STATE()         __disable_irq()
-#   define SET_GLOBAL_INTERRUPT_STATE(__STATE)  if (!__STATE) { __enable_irq(); }
-typedef int   istate_t;
-#elif __IS_COMPILER_ARM_COMPILER_6__
-#   define GET_GLOBAL_INTERRUPT_STATE()         ____disable_irq()
-#   define SET_GLOBAL_INTERRUPT_STATE(__STATE)  ____set_PRIMASK(__STATE)        
+#elif __IS_COMPILER_ARM_COMPILER_5__ || __IS_COMPILER_ARM_COMPILER_6__
+#   define GET_GLOBAL_INTERRUPT_STATE()         __get_PRIMASK()
+#   define SET_GLOBAL_INTERRUPT_STATE(__STATE)  __set_PRIMASK(__STATE)
 typedef int   istate_t;
 #elif __IS_COMPILER_GCC__
-typedef int   istate_t;
 #   define GET_GLOBAL_INTERRUPT_STATE()         __get_PRIMASK()
+#   define SET_GLOBAL_INTERRUPT_STATE(__STATE)  __set_PRIMASK(__STATE)
+typedef uint32_t   istate_t;
+#else
+typedef uint32_t   istate_t;
+#   define GET_GLOBAL_INTERRUPT_STATE()         ____get_PRIMASK()
 
 /**
   \brief   Get Priority Mask
   \details Returns the current state of the priority mask bit from the Priority Mask Register.
   \return               Priority Mask value
  */
-__attribute__((always_inline)) static inline uint32_t __get_PRIMASK(void)
+__attribute__((always_inline)) static inline uint32_t ____get_PRIMASK(void)
 {
     unsigned int result;
 
@@ -266,21 +257,17 @@ __attribute__((always_inline)) static inline uint32_t __get_PRIMASK(void)
     return(result);
 }
 
-#   define SET_GLOBAL_INTERRUPT_STATE(__STATE)  __set_PRIMASK(__STATE)
+#   define SET_GLOBAL_INTERRUPT_STATE(__STATE)  ____set_PRIMASK(__STATE)
 
 /**
   \brief   Set Priority Mask
   \details Assigns the given value to the Priority Mask Register.
   \param [in]    priMask  Priority Mask
  */
-__attribute__((always_inline)) static inline void __set_PRIMASK(unsigned int priMask)
+__attribute__((always_inline)) static inline void ____set_PRIMASK(uint32_t priMask)
 {
     __asm__ volatile ("MSR primask, %0" : : "r" (priMask) : "memory");
 }
-
-
-#else
-#error No support for interrupt state access
 #endif
 
 /*============================ TYPES =========================================*/

--- a/sources/gmsi/utilities/arm/signal.c
+++ b/sources/gmsi/utilities/arm/signal.c
@@ -40,9 +40,8 @@ void init_lock(locker_t *ptLock)
     if (NULL == ptLock) {
         return ;
     }
-    SAFE_ATOM_CODE (
-        (*ptLock) = UNLOCKED;
-    )
+    
+    (*ptLock) = UNLOCKED;
 }
 
 /*! \brief try to enter a section
@@ -56,12 +55,14 @@ bool enter_lock(locker_t *ptLock)
     if (NULL == ptLock) {
         return true;
     }
-    SAFE_ATOM_CODE(
-        if (!(*ptLock)) {
-            (*ptLock) = LOCKED;
-            bResult = true;
-        }
-    )
+    if (UNLOCKED == (*ptLock)) {
+        SAFE_ATOM_CODE(
+            if (UNLOCKED == (*ptLock)) {
+                (*ptLock) = LOCKED;
+                bResult = true;
+            }
+        )
+    }
         
     return bResult;
 }
@@ -76,9 +77,8 @@ void leave_lock(locker_t *ptLock)
     if (NULL == ptLock) {
         return ;
     }
-    SAFE_ATOM_CODE(
-        (*ptLock) = UNLOCKED;
-    )
+    
+    (*ptLock) = UNLOCKED;
 }
 
 /*! \brief get locker status
@@ -87,16 +87,11 @@ void leave_lock(locker_t *ptLock)
  */
 bool check_lock(locker_t *ptLock)
 {
-    bool bResult = UNLOCKED;
     if (NULL == ptLock) {
         return false;
     }
-    
-    SAFE_ATOM_CODE(
-        bResult = (*ptLock);
-    )
-    
-    return bResult;
+
+    return (*ptLock);
 }
 
 /* EOF */

--- a/sources/gmsi/utilities/compiler.h
+++ b/sources/gmsi/utilities/compiler.h
@@ -23,36 +23,36 @@
 
 //! \note for IAR
 #ifdef __IS_COMPILER_IAR__
-    #undef __IS_COMPILER_IAR__
+#   undef __IS_COMPILER_IAR__
 #endif
 #if defined(__IAR_SYSTEMS_ICC__)
-#define __IS_COMPILER_IAR__                 1
+#   define __IS_COMPILER_IAR__                 1
 #endif
 
 //! \note for gcc
 #ifdef __IS_COMPILER_GCC__
-    #undef __IS_COMPILER_GCC__
+#   undef __IS_COMPILER_GCC__
 #endif
 #if defined(__GNUC__)
-#define __IS_COMPILER_GCC__                 1
+#   define __IS_COMPILER_GCC__                 1
 #endif
 //! @}
 
 //! \note for arm compiler 5
 #ifdef __IS_COMPILER_ARM_COMPILER_5__
-    #undef __IS_COMPILER_ARM_COMPILER_5__
+#   undef __IS_COMPILER_ARM_COMPILER_5__
 #endif
 #if ((__ARMCC_VERSION >= 5000000) && (__ARMCC_VERSION < 6000000))
-#define __IS_COMPILER_ARM_COMPILER_5__      1
+#   define __IS_COMPILER_ARM_COMPILER_5__      1
 #endif
 //! @}
 
 //! \note for arm compiler 6
 #ifdef __IS_COMPILER_ARM_COMPILER_6__
-    #undef __IS_COMPILER_ARM_COMPILER_6__
+#   undef __IS_COMPILER_ARM_COMPILER_6__
 #endif
 #if ((__ARMCC_VERSION >= 6000000) && (__ARMCC_VERSION < 7000000))
-#define __IS_COMPILER_ARM_COMPILER_6__      1
+#   define __IS_COMPILER_ARM_COMPILER_6__      1
 #endif
 //! @}
 
@@ -60,12 +60,12 @@
 /* -------------------  Start of section using anonymous unions  ------------------ */
 #if     __IS_COMPILER_ARM_COMPILER_5__
     //#pragma push
-    #pragma anon_unions
+#   pragma anon_unions
 #elif   __IS_COMPILER_IAR__
-    #pragma language=extended
+#   pragma language=extended
 #elif   __IS_COMPILER_GCC__ || __IS_COMPILER_ARM_COMPILER_6__
     /* anonymous unions are enabled by default */
-#else
+#   else
     #warning Not supported compiler type
 #endif
 
@@ -85,11 +85,6 @@
 //#warning No specified MCU type! use arm as default
 #   include ".\arm\arm_compiler.h"
 #endif
-   
-#ifndef ATOM_INT_SIZE
-#define ATOM_INT_SIZE           2
-#endif 
-     
 
 //! \brief system macros
 #define MAX(__A,__B)  (((__A) > (__B)) ? (__A) : (__B))
@@ -111,18 +106,9 @@
                         (__MASK((__TO)+1)-__MASK(__FROM))
 #endif
 
-#ifndef __CONNECT
-#	define __CONNECT(a, b)			a ## b
+#ifndef UNUSED_PARAM
+# define UNUSED_PARAM(__VAL)    (__VAL) = (__VAL)
 #endif
-
-#ifndef REFERENCE_PARAMETER
-# define REFERENCE_PARAMETER(a)		(a) = (a)
-#endif
-
-#ifndef dimof
-#	define dimof(arr)				(sizeof(arr) / sizeof((arr)[0]))
-#endif
-     
      
 //! \brief This macro convert variable types between different datatypes.
 #define __TYPE_CONVERT(__ADDR,__TYPE)       (*((__TYPE *)(__ADDR)))


### PR DESCRIPTION
- Define unified behaviour for DISABLE_GLOBAL_INTERRUPT macro
- Improve the real-time performance of LOCK and LOCK_CHECKER macro
    - only enter_lock or similar operation will require atom code protection.