### PR TITLE
Update simple_fsm and block

### DIFF
--- a/example/build/mdk/Blinky.uvoptx
+++ b/example/build/mdk/Blinky.uvoptx
@@ -1080,7 +1080,7 @@
       <GroupNumber>4</GroupNumber>
       <FileNumber>54</FileNumber>
       <FileType>1</FileType>
-      <tvExp>1</tvExp>
+      <tvExp>0</tvExp>
       <tvExpOptDlg>0</tvExpOptDlg>
       <bDave2>0</bDave2>
       <PathWithFileName>..\..\app_platform\app_platform.c</PathWithFileName>
@@ -1148,7 +1148,7 @@
 
   <Group>
     <GroupName>::Device</GroupName>
-    <tvExp>0</tvExp>
+    <tvExp>1</tvExp>
     <tvExpOptDlg>0</tvExpOptDlg>
     <cbSel>0</cbSel>
     <RteFlg>1</RteFlg>

--- a/sources/gmsi/service/communication/frame/es_simple_frame/es_simple_frame.c
+++ b/sources/gmsi/service/communication/frame/es_simple_frame/es_simple_frame.c
@@ -403,9 +403,9 @@ private fsm_implementation(es_simple_frame_decoder)
                 }
                 
                 CRC(this.hwCheckSUM, chData);
-                update_state_to(WAIT_FOR_LENGTH_H);
-                
                 ((uint8_t *)&this.hwLength)[0] = chData;
+                
+                update_state_to(WAIT_FOR_LENGTH_H);
             )
                 
             state(WAIT_FOR_LENGTH_H,
@@ -424,9 +424,9 @@ private fsm_implementation(es_simple_frame_decoder)
                     //! data is too big 
                     this.bUnsupportFrame = true;
                 } 
+                this.hwCounter = 0;
                 
                 update_state_to(WAIT_FOR_DATA);
-                this.hwCounter = 0;
             )
               
             state(WAIT_FOR_DATA,
@@ -443,8 +443,6 @@ private fsm_implementation(es_simple_frame_decoder)
                 if (++this.hwCounter >= this.hwLength) {
                     transfer_to(WAIT_FOR_CHECK_SUM_L);
                 }
-                
-                fsm_continue();
             )
               
             state(WAIT_FOR_CHECK_SUM_L,

--- a/sources/gmsi/service/communication/telegraph_engine/telegraph_engine.c
+++ b/sources/gmsi/service/communication/telegraph_engine/telegraph_engine.c
@@ -255,7 +255,7 @@ private fsm_implementation(telegraph_engine_task)
                 if (IS_FSM_ERR(tResult)) {
                     fsm_report(tResult);
                 } else if (fsm_rt_cpl != tResult) {
-                    fsm_continue();
+                    fsm_on_going();
                 } 
                 
                 if (NULL == target.fnHandler) {
@@ -275,7 +275,7 @@ private fsm_implementation(telegraph_engine_task)
         
             //! add the target telegraph to listener list
             if (!try_to_listen(this.ptCurrent)) {
-                fsm_continue();
+                fsm_on_going();
             }
             
             transfer_to(FETCH_TELEGRAPH);

--- a/sources/gmsi/service/memory/block/block.h
+++ b/sources/gmsi/service/memory/block/block.h
@@ -33,12 +33,11 @@
 //! @{
 declare_class(block_t)
 extern_class(block_t)
-    inherit(__single_list_node_t)
-    uint32_t wBlockSize;
-    union {
-        uint32_t wSize;                                                         //!< memory block
-        uint32_t wBuffer;
-    };
+    implement(__single_list_node_t)
+    uint8_t  *pchBuffer;                            //!< buffer address
+    uint32_t IsReadOnly             : 1;
+    uint32_t BlockSize              : 15;
+    uint32_t Size                   : 16;           //!< memory block
 end_extern_class(block_t)
 //! @}
 
@@ -57,7 +56,10 @@ def_interface(i_block_t)
         void        (*Free)(block_pool_t *, block_t *);
         uint32_t    (*Count)(block_pool_t *ptObj);
     } Heap;
-    block_t *       (*Init)(block_t *ptBlock, uint_fast16_t hwSize);
+    block_t *       (*Init)(block_t *ptBlock, 
+                            void *pBuffer, 
+                            uint_fast16_t hwSize, 
+                            bool bIsReadOnly);
     struct {
         uint32_t    (*Get)(block_t *);
         void        (*Set)(block_t *, uint32_t);

--- a/sources/gmsi/service/time/multiple_delay/multiple_delay.c
+++ b/sources/gmsi/service/time/multiple_delay/multiple_delay.c
@@ -463,7 +463,7 @@ private fsm_implementation(multiple_delay_task)
             )
             
             if (target.wOldCounter == target.wSavedCounter) {
-                fsm_continue();
+                fsm_on_going();
             }
             
             target.wOldCounter = target.wSavedCounter;
@@ -531,8 +531,6 @@ private fsm_implementation(multiple_delay_task)
                             (multiple_delay_item_t *)ptItem);
                 
             } while(false);
-            
-            fsm_continue();
         )
             
         state(RAISE_LOW_PRIORITY_EVENT,
@@ -557,8 +555,6 @@ private fsm_implementation(multiple_delay_task)
                             (multiple_delay_item_t *)ptItem);
                 
             } while(false);
-            
-            fsm_continue();
         )
 
     )

--- a/sources/gmsi/utilities/ooc.h
+++ b/sources/gmsi/utilities/ooc.h
@@ -246,24 +246,24 @@
 /*! \note When deriving a new class from a base class, you should use INHERIT 
  *        other than IMPLEMENT, although they looks the same now.
  */
-#define __INHERIT(__TYPE)           INHERIT_EX(__TYPE, base__##__TYPE)
+#define __INHERIT(__TYPE)           INHERIT_EX(__TYPE, use_as_##__TYPE)
 #define INHERIT(__TYPE)             __INHERIT(__TYPE)
 
 /*! \note You can only use IMPLEMENT when defining INTERFACE. For Implement 
  *        interface when defining CLASS, you should use DEF_CLASS_IMPLEMENT 
  *        instead.
  */
-#define __IMPLEMENT(__INTERFACE)    IMPLEMENT_EX(__INTERFACE, base__##__INTERFACE)
+#define __IMPLEMENT(__INTERFACE)    IMPLEMENT_EX(__INTERFACE, use_as_##__INTERFACE)
 #define IMPLEMENT(__INTERFACE)      __IMPLEMENT(__INTERFACE)  
 
 /*! \note if you have used INHERIT or IMPLEMENT to define a CLASS / INTERFACE, 
           you can use OBJ_CONVERT_AS to extract the reference to the inherited 
           object. 
   \*/
-#define __OBJ_CONVERT_AS(__OBJ, __INTERFACE)    (__OBJ.base__##__INTERFACE)
+#define __OBJ_CONVERT_AS(__OBJ, __INTERFACE)    (__OBJ.use_as_##__INTERFACE)
 #define OBJ_CONVERT_AS(__OBJ, __INTERFACE)      __OBJ_CONVERT_AS((__OBJ), __INTERFACE)          
 
-#define __REF_OBJ_AS(__OBJ, __TYPE)             (&(__OBJ.base__##__TYPE))
+#define __REF_OBJ_AS(__OBJ, __TYPE)             (&(__OBJ.use_as_##__TYPE))
 #define REF_OBJ_AS(__OBJ, __TYPE)               __REF_OBJ_AS((__OBJ), __TYPE)
 
 #define REF_INTERFACE(__INTERFACE)      const __INTERFACE *ptMethod;

--- a/sources/gmsi/utilities/simple_fsm.h
+++ b/sources/gmsi/utilities/simple_fsm.h
@@ -111,9 +111,13 @@
 #define call_fsm(__NAME, __FSM, ...)                                            \
         __NAME((__FSM) __VA_ARGS__)
 
-#define state(__STATE, ...)                                                     \
-        case __STATE:                                                           \
-            {__VA_ARGS__;}
+#define __state(__STATE, ...)                                                   \
+            case __STATE:{                                                      \
+        __state_entry_##__STATE:                                                \
+                __VA_ARGS__;                                                    \
+            }break;
+            
+#define state(__STATE, ...)                 __state(__STATE, __VA_ARGS__)
 
 #define on_start(...)                       {__VA_ARGS__;}
 
@@ -123,11 +127,13 @@
 #define fsm_report(__ERROR) do {reset_fsm(); return (fsm_rt_t)(__ERROR); } while(0);
 #define fsm_wait_for_obj()  return fsm_rt_wait_for_obj;
 #define fsm_on_going()      return fsm_rt_on_going;
-#define fsm_continue()      break
+
+//! fsm_continue is deprecated, should not be used anymore
+//#define fsm_continue()      break
 
 
 #define update_state_to(__STATE)                                                \
-        { ptThis->chState = (__STATE); }
+        { ptThis->chState = (__STATE); goto __state_entry_##__STATE;}
 
 #define transfer_to(__STATE)                                                    \
          { update_state_to(__STATE); fsm_on_going() } 
@@ -173,6 +179,8 @@
             case 0:                                                             \
                 ptThis->chState++;                                              \
             __VA_ARGS__                                                         \
+            default:                                                            \
+            return fsm_rt_err;                                                  \
         }                                                                       \
                                                                                 \
         return fsm_rt_on_going;                                                 \
@@ -200,9 +208,10 @@
             } while(1);                                                         
             
 #define privilege_state(__STATE, ...)                                           \
-            __privilege_state((__STATE), __VA_ARGS__)                                      
+            __privilege_state(__STATE, __VA_ARGS__)                                      
             
-#define privilege_group(...)  {while(1) {__VA_ARGS__;} break;}
+
+#define privilege_group(...)  { __VA_ARGS__;}
 
 #define privilege_body(...)                                                     \
         do {                                                                    \


### PR DESCRIPTION
- remove the fsm_continue
- make state() reflexive
- change behaviour of update_state_to()
    now this macro will goto the state immediately without yield
- update corresponding source code

- add read-only support to block, now block can pointer to rom memory
- limit the supported block size from 0xFFFFFFFF to 0xFFFD. Which covers 32K.